### PR TITLE
Test bootstrapping (`userscripter init`) in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           npm run build
         env:
           CI: true
-      - name: Install
+      - name: Install CLI tool
         run: |
           npm install --global .
       - name: Bootstrap

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,3 @@ jobs:
         working-directory: bootstrapped-userscript
         run: |
           echo "$PATH"
-          which userscripter
-          userscripter init
-          npm install
-          npm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,9 @@ jobs:
         run: |
           npm install --global .
       - name: Bootstrap
-        working-directory: bootstrapped-userscript
         run: |
+          mkdir bootstrapped-userscript
+          cd $_
           userscripter init
           npm install
           npm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install CLI tool
         run: |
           npm install --global .
-      - name: Bootstrap
+      - name: Bootstrap userscript
         run: |
           mkdir bootstrapped-userscript
           cd $_

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,8 +38,9 @@ jobs:
       - name: Install
         run: |
           npm install --global .
-          echo "$PATH"
       - name: Bootstrap
         working-directory: bootstrapped-userscript
         run: |
-          echo "$PATH"
+          userscripter init
+          npm install
+          npm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,3 +35,12 @@ jobs:
           npm run build
         env:
           CI: true
+      - name: Install
+        run: |
+          npm install --global .
+      - name: Bootstrap
+        working-directory: bootstrapped-userscript
+        run: |
+          userscripter init
+          npm install
+          npm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
         run: |
           npm install --global .
       - name: Bootstrap userscript
+        working-directory: ${{ runner.temp }}
         run: |
           mkdir bootstrapped-userscript
           cd $_

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
       - name: Install
         run: |
           npm install --global .
+          echo "$PATH"
       - name: Bootstrap
         working-directory: bootstrapped-userscript
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
           CI: true
       - name: Install
         run: |
+          npm trololo
           npm install --global .
       - name: Bootstrap
         working-directory: bootstrapped-userscript

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,6 @@ jobs:
           CI: true
       - name: Install
         run: |
-          npm trololo
           npm install --global .
       - name: Bootstrap
         working-directory: bootstrapped-userscript

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,8 @@ jobs:
       - name: Bootstrap
         working-directory: bootstrapped-userscript
         run: |
+          echo "$PATH"
+          which userscripter
           userscripter init
           npm install
           npm run build


### PR DESCRIPTION
Thanks to #31, I noticed that we weren't testing the bootstrapping/init
feature at all. This PR should make sure that the `userscripter` binary
can be installed globally and that we at least always generate a
userscript that can be built.

Resolves #32.