### PR TITLE
Fix Content Security Policy + eval issue

### DIFF
--- a/src/build/internal/webpack.ts
+++ b/src/build/internal/webpack.ts
@@ -106,6 +106,7 @@ export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configu
             path: resolveIn(rootDir)(outDir),
             filename: distFileName(id, "user"),
         },
+        devtool: mode === Mode.production ? "hidden-source-map" : "inline-cheap-source-map",
         stats: {
             depth: false,
             hash: false,


### PR DESCRIPTION
`eval` in the built userscript doesn't work with some sites due to their CSP.

Resolves #30.