### PR TITLE
feat: Make date suffix in version optional

### DIFF
--- a/src/build/internal/configuration.ts
+++ b/src/build/internal/configuration.ts
@@ -16,10 +16,12 @@ export const HOSTED_AT_EXAMPLE = "https://example.com/userscripts";
 
 export type BuildConfig = Readonly<{
     allowJs: boolean
+    devOptions: {
+        appendDateToVersion: boolean
+    }
     id: string
     hostedAt: string | null
     mainFile: string
-    dateAsSemverVersion: boolean
     mode: Mode
     nightly: boolean
     now: Date

--- a/src/build/internal/configuration.ts
+++ b/src/build/internal/configuration.ts
@@ -16,8 +16,10 @@ export const HOSTED_AT_EXAMPLE = "https://example.com/userscripts";
 
 export type BuildConfig = Readonly<{
     allowJs: boolean
-    devOptions: {
-        appendDateToVersion: boolean
+    appendDateToVersion: {
+        development: boolean
+        nightly: boolean
+        production: boolean
     }
     id: string
     hostedAt: string | null

--- a/src/build/internal/configuration.ts
+++ b/src/build/internal/configuration.ts
@@ -19,6 +19,7 @@ export type BuildConfig = Readonly<{
     id: string
     hostedAt: string | null
     mainFile: string
+    dateAsSemverVersion: boolean
     mode: Mode
     nightly: boolean
     now: Date

--- a/src/build/internal/webpack.ts
+++ b/src/build/internal/webpack.ts
@@ -33,12 +33,14 @@ export const DEFAULT_BUILD_CONFIG: (x: {
     now: Date
 }) => BuildConfig = x => ({
     allowJs: false,
+    devOptions: {
+        appendDateToVersion: true,
+    },
     id: x.id,
     hostedAt: null,
     mainFile: "main.ts",
     mode: Mode.development,
     nightly: false,
-    dateAsSemverVersion: true,
     now: x.now,
     outDir: "dist",
     rootDir: x.rootDir,
@@ -62,11 +64,11 @@ export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configu
     const overridden = overrideBuildConfig(x.buildConfig, x.env);
     const {
         allowJs,
+        devOptions,
         id,
         mainFile,
         mode,
         nightly,
-        dateAsSemverVersion,
         now,
         outDir,
         rootDir,
@@ -79,7 +81,7 @@ export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configu
         return name + (nightly ? " Nightly" : "");
     }
     function finalVersion(version: string): string {
-        return version + ((nightly || mode === Mode.development) && dateAsSemverVersion ? "." + dateAsSemver(now) : "");
+        return version + ((nightly || mode === Mode.development) && devOptions.appendDateToVersion ? "." + dateAsSemver(now) : "");
     }
     const finalMetadata = (() => {
         const unfinishedMetadata = x.metadata(overridden.buildConfig);

--- a/src/build/internal/webpack.ts
+++ b/src/build/internal/webpack.ts
@@ -33,8 +33,10 @@ export const DEFAULT_BUILD_CONFIG: (x: {
     now: Date
 }) => BuildConfig = x => ({
     allowJs: false,
-    devOptions: {
-        appendDateToVersion: true,
+    appendDateToVersion: {
+        development: true,
+        nightly: true,
+        production: false,
     },
     id: x.id,
     hostedAt: null,
@@ -64,7 +66,7 @@ export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configu
     const overridden = overrideBuildConfig(x.buildConfig, x.env);
     const {
         allowJs,
-        devOptions,
+        appendDateToVersion,
         id,
         mainFile,
         mode,
@@ -81,7 +83,14 @@ export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configu
         return name + (nightly ? " Nightly" : "");
     }
     function finalVersion(version: string): string {
-        return version + ((nightly || mode === Mode.development) && devOptions.appendDateToVersion ? "." + dateAsSemver(now) : "");
+        switch (true) {
+            case nightly && appendDateToVersion.nightly:
+            case mode === Mode.development && appendDateToVersion.development:
+            case mode === Mode.production && appendDateToVersion.production:
+                return version + "." + dateAsSemver(now);
+            default:
+                return version;
+        }
     }
     const finalMetadata = (() => {
         const unfinishedMetadata = x.metadata(overridden.buildConfig);

--- a/src/build/internal/webpack.ts
+++ b/src/build/internal/webpack.ts
@@ -38,6 +38,7 @@ export const DEFAULT_BUILD_CONFIG: (x: {
     mainFile: "main.ts",
     mode: Mode.development,
     nightly: false,
+    dateAsSemverVersion: true,
     now: x.now,
     outDir: "dist",
     rootDir: x.rootDir,
@@ -65,6 +66,7 @@ export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configu
         mainFile,
         mode,
         nightly,
+        dateAsSemverVersion,
         now,
         outDir,
         rootDir,
@@ -77,7 +79,7 @@ export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configu
         return name + (nightly ? " Nightly" : "");
     }
     function finalVersion(version: string): string {
-        return version + (nightly || mode === Mode.development ? "." + dateAsSemver(now) : "");
+        return version + ((nightly || mode === Mode.development) && dateAsSemverVersion ? "." + dateAsSemver(now) : "");
     }
     const finalMetadata = (() => {
         const unfinishedMetadata = x.metadata(overridden.buildConfig);


### PR DESCRIPTION
The constant overriding of version with `dateAsSemver` when in development can cause trouble when trying to create and e2e test the userscript using webextension (ex: chrome refuse to load a webextension with a version is not formated like `x.x.x`).

Even if we can build using `USERSCRIPTER_MODE=production` to fix the version issue. But that also minify the code, making the debuging/e2e tests writing harder.

So I simply added an option into the config to opt-out of this default behavior if needed.