### PR TITLE
style: Fix import order and grouping (#52)

### DIFF
--- a/bootstrap/metadata.ts
+++ b/bootstrap/metadata.ts
@@ -1,7 +1,7 @@
+import { Metadata } from "userscript-metadata";
 import {
     BuildConfig,
 } from "userscripter/build";
-import { Metadata } from "userscript-metadata";
 
 import U from "./src/userscript";
 

--- a/bootstrap/webpack.config.ts
+++ b/bootstrap/webpack.config.ts
@@ -1,10 +1,10 @@
 import * as AppRootPath from "app-root-path";
-
 import {
     createWebpackConfig,
     DEFAULT_BUILD_CONFIG,
     DEFAULT_METADATA_SCHEMA,
 } from "userscripter/build";
+
 import METADATA from "./metadata";
 import * as CONFIG from "./src/config";
 import * as SITE from "./src/site";

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -2,8 +2,9 @@
 
 // tslint:disable:no-console
 
-import * as fsx from "fs-extra";
 import * as path from "path";
+
+import * as fsx from "fs-extra";
 import * as yargs from "yargs";
 
 const BOOTSTRAP_ROOT = path.resolve(__dirname, "..", "bootstrap");

--- a/src/build/internal/webpack.ts
+++ b/src/build/internal/webpack.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+
 import { everythingInPackage } from "restrict-imports-loader";
 import TerserPlugin from "terser-webpack-plugin";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";

--- a/tslint.json
+++ b/tslint.json
@@ -14,6 +14,28 @@
             {
                 "import-sources-order": "case-insensitive",
                 "named-imports-order": "lowercase-last",
+                "groups": [
+                    {
+                        "name": "builtin",
+                        "match": "^(fs|path)$",
+                        "order": 10
+                    },
+                    {
+                        "name": "external",
+                        "match": "^(?!\\.{1,2}/)",
+                        "order": 20
+                    },
+                    {
+                        "name": "parent",
+                        "match": "^\\.{2}\/",
+                        "order": 30
+                    },
+                    {
+                        "name": "sibling",
+                        "match": "^\\.\/",
+                        "order": 40
+                    }
+                ],
                 "grouped-imports": true
             }
         ],


### PR DESCRIPTION
Would have become errors in the upcoming switch from TSLint to ESLint.