### PR TITLE
chore: Upgrade to TypeScript 4 (#51)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6303,6 +6303,13 @@
         "loader-utils": "^1.2.3",
         "schema-utils": "^2.5.0",
         "typescript": "^3.7.2"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.9.9",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+          "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
+        }
       }
     },
     "ret": {
@@ -7514,9 +7521,10 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ=="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "dev": true
     },
     "typical": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ts-jest": "^24.1.0",
     "ts-preferences": "^2.0.0",
     "tslint": "^5.20.1",
-    "typescript": "^3.7.2"
+    "typescript": "^4.2.3"
   },
   "peerDependencies": {
     "ts-preferences": "^2.0.0"


### PR DESCRIPTION
Doesn't seem to break anything, at least not in Better SweClockers. And
TypeScript doesn't follow SemVer anyway.