### PR TITLE
ci: Drop Node 14 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
         repository:
           - SimonAlling/better-sweclockers
           - SimonAlling/example-userscript
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
       fail-fast: false
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}
@@ -56,7 +56,7 @@ jobs:
         repository:
           - SimonAlling/better-sweclockers
           - SimonAlling/example-userscript
-        node-version: [16.x, 18.x]
+        node-version: [16.x]
       fail-fast: false
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Node 14 went EOL on 2023-04-30, according to [Node's release schedule].

Also, the `Build userscript` step in CI fails with Node 14 for both dependent userscripts:

    node_modules/sass/types/legacy/function.d.ts:132:17 - error TS1256: A rest element must be last in a tuple type.

    132       ...args: [...LegacyValue[], LegacyAsyncFunctionDone]
                        ~~~~~~~~~~~~~~~~

#86 suppressed that error in the bootstrapped userscript, but I don't know exactly if or how that is related to its occurrence in the dependent userscripts.

[Node's release schedule]: https://nodejs.dev/en/about/releases/