### PR TITLE
fix: Enable `skipLibCheck` in bootstrapped userscript

### DIFF
--- a/bootstrap/tsconfig.json
+++ b/bootstrap/tsconfig.json
@@ -5,6 +5,7 @@
             "~src/*": [ "./src/*" ]
         },
         "target": "es6",
+        "skipLibCheck": true,
         "strict": true,
         "module": "es2015",
         "moduleResolution": "node",


### PR DESCRIPTION
Every single change I've tried to make lately has been blocked by an error in the `Bootstrap userscript` step (Node 14 and 16). Specifically, `npm run build` fails:

    Error: node_modules/sass/types/legacy/function.d.ts(132,17): error TS1256: A rest element must be last in a tuple type.

The problem is that the build is not deterministic, since it uses `npm install`, not `npm ci` (which requires a `package-lock.json`). Userscripter's `package.json` specifies `"sass": "^1.32.8"`, so `npm install` will always install the latest version of Sass with major version 1 that happens to exist at that point in time.

On 2021-06-01, in [2cb85cb3] (so probably in version [1.34.1]), Sass added a declaration file containing the type `[...Value, (type: Value) => void]`, causing the error above. (`Value` was later renamed to `LegacyValue` in [c8f6dbf3].) [TypeScript 4.0] introduced support for such types, but since we use `awesome-typescript-loader`, we're currently restricted to TypeScript <4.0.

For some reason, the `Build userscript` step fails (with the same error as above, and for both Example Userscript and Better SweClockers) with Node 14 but not with Node 16, regardless of this PR. The purpose of building dependent userscripts is to prevent accidentally breaking them; this PR doesn't do that (since they're already broken), so we can safely ignore those errors. Node 14 is also EOL; support is removed in #85.

I don't know how to solve the root issue, but this PR should at least unblock us so that we can do anything at all.

[1.34.1]: https://www.npmjs.com/package/sass/v/1.34.1
[2cb85cb3]: https://github.com/sass/sass/commit/2cb85cb3679c18dc9e7812c19abfa3a7180875da
[c8f6dbf3]: https://github.com/sass/sass/commit/c8f6dbf3d4f0ae4cab8dc86205fb8d78f9ad7502
[TypeScript 4.0]: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html