### PR TITLE
feat!: Remove `allowJs` configuration option

### DIFF
--- a/src/build/internal/configuration.ts
+++ b/src/build/internal/configuration.ts
@@ -15,7 +15,6 @@ const ENV_VAR_PREFIX = "USERSCRIPTER_";
 export const HOSTED_AT_EXAMPLE = "https://example.com/userscripts";
 
 export type BuildConfig = Readonly<{
-    allowJs: boolean
     appendDateToVersion: {
         development: boolean
         nightly: boolean

--- a/src/build/internal/webpack.ts
+++ b/src/build/internal/webpack.ts
@@ -33,7 +33,6 @@ export const DEFAULT_BUILD_CONFIG: (x: {
     id: string
     now: Date
 }) => BuildConfig = x => ({
-    allowJs: false,
     appendDateToVersion: {
         development: true,
         nightly: true,
@@ -66,7 +65,6 @@ export const DEFAULT_METADATA_SCHEMA: Metadata.ValidateOptions = {
 export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configuration {
     const overridden = overrideBuildConfig(x.buildConfig, x.env);
     const {
-        allowJs,
         appendDateToVersion,
         id,
         mainFile,
@@ -171,7 +169,6 @@ export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configu
                     loaders: [
                         {
                             loader: require.resolve("ts-loader"),
-                            options: { compilerOptions: { allowJs } },
                         },
                         {
                             loader: require.resolve("restrict-imports-loader"),


### PR DESCRIPTION
We need to get rid of some complexity, and this option just isn't very useful in my experience.