### PR TITLE
fix: Upgrade restrict-imports-loader to v3.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "loader-utils": "^1.2.3",
         "node-sass-utils": "^1.1.3",
         "raw-loader": "^4.0.0",
-        "restrict-imports-loader": "^3.2.1",
+        "restrict-imports-loader": "^3.2.5",
         "sass": "^1.32.8",
         "sass-loader": "10.1.1",
         "schema-utils": "^2.5.0",
@@ -720,15 +720,6 @@
       "integrity": "sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/schema-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/schema-utils/-/schema-utils-2.4.0.tgz",
-      "integrity": "sha512-454hrj5gz/FXcUE20ygfEiN4DxZ1sprUo0V1gqIqkNZ/CzoEzAZEll2uxMsuyz6BYjiQan4Aa65xbTemfzW9hQ==",
-      "deprecated": "This is a stub types definition. schema-utils provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "schema-utils": "*"
       }
     },
     "node_modules/@types/source-list-map": {
@@ -9065,13 +9056,12 @@
       "deprecated": "https://github.com/lydell/resolve-url#deprecated"
     },
     "node_modules/restrict-imports-loader": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/restrict-imports-loader/-/restrict-imports-loader-3.2.1.tgz",
-      "integrity": "sha512-fYTgA/B2+gRmrEdxF75gPLuXkxpXOAfBZoOalSe2yvrcvSwjORYstnjQTC0M3ep9QbiBfwl2MvLnIi6dmrPnGA==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/restrict-imports-loader/-/restrict-imports-loader-3.2.5.tgz",
+      "integrity": "sha512-donLB0ciPOb33f1exhJB2ui3z5o3M4/frjAGcR+9wkxeXZgVFlFMIj4GDyq1HLrHo1iF0DHSV0KIRhzxhFXHTg==",
       "dependencies": {
         "@types/json-schema": "^7.0.3",
         "@types/loader-utils": "^1.1.3",
-        "@types/schema-utils": "^2.4.0",
         "loader-utils": "^1.2.3",
         "schema-utils": "^2.5.0",
         "typescript": "^3.7.2"
@@ -12144,14 +12134,6 @@
       "integrity": "sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==",
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/schema-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/schema-utils/-/schema-utils-2.4.0.tgz",
-      "integrity": "sha512-454hrj5gz/FXcUE20ygfEiN4DxZ1sprUo0V1gqIqkNZ/CzoEzAZEll2uxMsuyz6BYjiQan4Aa65xbTemfzW9hQ==",
-      "requires": {
-        "schema-utils": "*"
       }
     },
     "@types/source-list-map": {
@@ -18783,13 +18765,12 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "restrict-imports-loader": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/restrict-imports-loader/-/restrict-imports-loader-3.2.1.tgz",
-      "integrity": "sha512-fYTgA/B2+gRmrEdxF75gPLuXkxpXOAfBZoOalSe2yvrcvSwjORYstnjQTC0M3ep9QbiBfwl2MvLnIi6dmrPnGA==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/restrict-imports-loader/-/restrict-imports-loader-3.2.5.tgz",
+      "integrity": "sha512-donLB0ciPOb33f1exhJB2ui3z5o3M4/frjAGcR+9wkxeXZgVFlFMIj4GDyq1HLrHo1iF0DHSV0KIRhzxhFXHTg==",
       "requires": {
         "@types/json-schema": "^7.0.3",
         "@types/loader-utils": "^1.1.3",
-        "@types/schema-utils": "^2.4.0",
         "loader-utils": "^1.2.3",
         "schema-utils": "^2.5.0",
         "typescript": "^3.7.2"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "loader-utils": "^1.2.3",
     "node-sass-utils": "^1.1.3",
     "raw-loader": "^4.0.0",
-    "restrict-imports-loader": "^3.2.1",
+    "restrict-imports-loader": "^3.2.5",
     "sass": "^1.32.8",
     "sass-loader": "10.1.1",
     "schema-utils": "^2.5.0",


### PR DESCRIPTION
Version 3.2.5 removed `@types/schema-utils` in accordance with this warning that we, and all consumers, get on every `npm ci`:

    npm WARN deprecated @types/schema-utils@2.4.0: This is a stub types definition. schema-utils provides its own type definitions, so you do not need this installed.