### PR TITLE
chore: v2.0.0

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,6 +17,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           validateSingleCommit: true
-          subjectPattern: ^(?![a-z]).+$
+          subjectPattern: ^(v\d+\.\d+\.\d+|(?![a-z]).+)$
           subjectPatternError: |
-            The subject "{subject}" found in the pull request title didn't match the required pattern. Please ensure that the subject doesn't start with a lowercase character.
+            The subject "{subject}" found in the pull request title didn't match the required pattern. Please ensure that the subject doesn't start with a lowercase character, or that it is a SemVer version (e.g. "v1.0.0").

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "userscripter",
-  "version": "1.3.3",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "userscripter",
-      "version": "1.3.3",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userscripter",
-  "version": "1.3.3",
+  "version": "2.0.0",
   "description": "Create userscripts in a breeze!",
   "keywords": [
     "userscript",


### PR DESCRIPTION
This version is breaking for any dependent userscripts that use the `allowJs` configuration option (#91).

The checked-in version number is changed from 1.3.3 to 2.0.0, but v1.4.0 and v1.5.0 also exist – just not on the trunk, but on a separate `v1` branch. Back then, the plan was to keep backporting features and fixes to older major versions, but I've abandoned those ambitions, since it's _a lot_ of work for little gain. From now on, new versions will only be released in a linear fashion.

Since we don't (yet) have automated releases (#66), this PR adapts the CI configuration to enable PRs like this one, whose subject start with a lowercase letter.

💡 `git show --color-words='[0-9.]+|.'`