### PR TITLE
feat!: Remove restrict-imports-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "loader-utils": "^1.2.3",
         "node-sass-utils": "^1.1.3",
         "raw-loader": "^4.0.0",
-        "restrict-imports-loader": "^3.2.5",
         "sass": "^1.32.8",
         "sass-loader": "10.1.1",
         "schema-utils": "^2.5.0",
@@ -9054,30 +9053,6 @@
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "deprecated": "https://github.com/lydell/resolve-url#deprecated"
-    },
-    "node_modules/restrict-imports-loader": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/restrict-imports-loader/-/restrict-imports-loader-3.2.5.tgz",
-      "integrity": "sha512-donLB0ciPOb33f1exhJB2ui3z5o3M4/frjAGcR+9wkxeXZgVFlFMIj4GDyq1HLrHo1iF0DHSV0KIRhzxhFXHTg==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.3",
-        "@types/loader-utils": "^1.1.3",
-        "loader-utils": "^1.2.3",
-        "schema-utils": "^2.5.0",
-        "typescript": "^3.7.2"
-      }
-    },
-    "node_modules/restrict-imports-loader/node_modules/typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
     },
     "node_modules/ret": {
       "version": "0.1.15",
@@ -18763,25 +18738,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-    },
-    "restrict-imports-loader": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/restrict-imports-loader/-/restrict-imports-loader-3.2.5.tgz",
-      "integrity": "sha512-donLB0ciPOb33f1exhJB2ui3z5o3M4/frjAGcR+9wkxeXZgVFlFMIj4GDyq1HLrHo1iF0DHSV0KIRhzxhFXHTg==",
-      "requires": {
-        "@types/json-schema": "^7.0.3",
-        "@types/loader-utils": "^1.1.3",
-        "loader-utils": "^1.2.3",
-        "schema-utils": "^2.5.0",
-        "typescript": "^3.7.2"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "3.9.9",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-          "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
-        }
-      }
     },
     "ret": {
       "version": "0.1.15",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "loader-utils": "^1.2.3",
     "node-sass-utils": "^1.1.3",
     "raw-loader": "^4.0.0",
-    "restrict-imports-loader": "^3.2.5",
     "sass": "^1.32.8",
     "sass-loader": "10.1.1",
     "schema-utils": "^2.5.0",

--- a/src/build/internal/webpack.ts
+++ b/src/build/internal/webpack.ts
@@ -1,6 +1,5 @@
 import * as path from "path";
 
-import { everythingInPackage } from "restrict-imports-loader";
 import TerserPlugin from "terser-webpack-plugin";
 import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 import * as Metadata from "userscript-metadata";
@@ -18,8 +17,6 @@ import { getGlobalFrom, withDartSassEncodedParameters } from "./sass";
 import { concat } from "./utilities";
 import { buildConfigErrors } from "./validation";
 import { UserscripterWebpackPlugin } from "./webpack-plugin";
-
-const USERSCRIPTER_BUILD = "userscripter/build";
 
 const EXTENSIONS = {
     TS: ["ts", "tsx"],
@@ -169,20 +166,6 @@ export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configu
                     loaders: [
                         {
                             loader: require.resolve("ts-loader"),
-                        },
-                        {
-                            loader: require.resolve("restrict-imports-loader"),
-                            options: {
-                                severity: "error",
-                                detailedErrorMessages: true,
-                                rules: [
-                                    {
-                                        restricted: everythingInPackage(USERSCRIPTER_BUILD),
-                                        severity: "fatal", // necessary to protect the user from being drowned in unintelligible errors
-                                        info: `"${USERSCRIPTER_BUILD}" and its submodules cannot be imported in the source directory ('${sourceDir}'). Please remove these imports:`,
-                                    },
-                                ],
-                            },
                         },
                     ],
                 },


### PR DESCRIPTION
I think this feature adds more complexity than it does value. While I believe consumers won't have their builds broken (unless they have a test that checks what happens if they `import { … } from "userscripter/build"`), I'm making it a breaking change because it is a feature being removed after all.