### PR TITLE
chore: Remove unused `webpack-userscript` module

### DIFF
--- a/src/build/webpack-userscript.d.ts
+++ b/src/build/webpack-userscript.d.ts
@@ -1,9 +1,0 @@
-// This declaration file contains only what's required for Userscripter.
-
-declare module "webpack-userscript" {
-    import { Compiler } from "webpack";
-    export default class WebpackUserscript {
-        constructor(options: any);
-        apply: (compiler: Compiler) => void;
-    }
-}


### PR DESCRIPTION
Should have been done in c8048d1c461a168d1672f0a7c9726fa77d357da5.