### PR TITLE
build: Make TypeScript configuration stricter

### DIFF
--- a/__tests__/operations.test.ts
+++ b/__tests__/operations.test.ts
@@ -2,7 +2,6 @@ import { operations } from "../src/lib";
 import {
   ALWAYS,
   DOMCONTENTLOADED,
-  LOAD,
 } from "../src/lib/environment";
 import { failureDescriber } from "../src/lib/errors";
 import {
@@ -63,7 +62,7 @@ function removeFooter(e: { footer: HTMLElement }) {
   e.footer.remove();
 }
 
-function logBlablablaProperty(e: { body: HTMLElement }) {
+function logBlablablaProperty(e: { body: HTMLElement }): string | void {
   const value = e.body.dataset[BLABLABLA];
   if (value !== undefined) {
     mockConsole.log(value);

--- a/src/build/internal/webpack.ts
+++ b/src/build/internal/webpack.ts
@@ -96,8 +96,8 @@ export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configu
         const unfinishedMetadata = x.metadata(overridden.buildConfig);
         return {
             ...unfinishedMetadata,
-            name: finalName(unfinishedMetadata.name as string),
-            version: finalVersion(unfinishedMetadata.version as string),
+            name: finalName(unfinishedMetadata["name"] as string),
+            version: finalVersion(unfinishedMetadata["version"] as string),
         };
     })();
     const finalManifest = x.manifest === undefined ? undefined : (() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,9 @@
 {
     "compilerOptions": {
+        "allowJs": false,
         "allowSyntheticDefaultImports": true,
+        "allowUnreachableCode": false,
+        "allowUnusedLabels": false,
         "declaration": true,
         "emitDecoratorMetadata": true,
         "esModuleInterop": true,
@@ -11,6 +14,10 @@
         ],
         "module": "es2015",
         "moduleResolution": "node",
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
         "outDir": ".",
         "removeComments": true,
         "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
         "moduleResolution": "node",
         "noFallthroughCasesInSwitch": true,
         "noImplicitReturns": true,
+        "noPropertyAccessFromIndexSignature": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "outDir": ".",


### PR DESCRIPTION
In my experience, the stricter the configuration is, the more value it brings, in general.

I've omitted `noUncheckedIndexedAccess` for now, because it causes non-trivial compilation errors in the existing code base.

💡 `git show --color-words=.`