### PR TITLE
fix: Make properties of 'e' enumerable

### DIFF
--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -115,7 +115,7 @@ function tryToPerform<K extends string>(o: Operation<K>): OperationResult {
         return { reason: Reason.DEPENDENCIES, dependencies: missingDependencies };
     }
     const e = queryResults.reduce(
-        (acc, x) => Object.defineProperty(acc, x.key, { value: x.element }),
+        (acc, x) => Object.defineProperty(acc, x.key, { value: x.element, enumerable: true }),
         {} as { [k in K]: HTMLElement },
     );
     return fromActionResult(o.action(e));


### PR DESCRIPTION
I ran into a confusing problem in SimonAlling/better-sweclockers#264. Consider an operation with this implementation:

```typescript
export default (e: {
    foo: HTMLElement,
    bar: HTMLElement,
    baz: HTMLElement,
}) => {
    for (const element of Object.values(e)) {
        console.log(element);
    }
};
```

One would expect that all three elements would be logged, but this operation actually does nothing at all. The reason is that the properties of `e` aren't enumerable, so `Object.values(e)` is an empty array.

While it's easy to come up with pathological examples of operations that will be broken by this change, it should be backward compatible for all practical intents and purposes.

💡 `git show --color-words=.`