### PR TITLE
chore: v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "userscripter",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "userscripter",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userscripter",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Create userscripts in a breeze!",
   "keywords": [
     "userscript",


### PR DESCRIPTION
This version shouldn't be breaking for most consumers, but could be if they depend on any imports from `userscripter/build` (which aren't intended to work) breaking the build with a descriptive error message instead of a cryptic wall of text.