### PR TITLE
refactor: Declare exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,33 @@
     "url": "https://github.com/simonalling/userscripter/issues"
   },
   "main": "lib/index",
+  "exports": {
+    ".": {
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js"
+    },
+    "./build": {
+      "import": "./build/index.mjs",
+      "require": "./build/index.js"
+    },
+    "./lib/*": {
+      "import": "./lib/*.mjs",
+      "require": "./lib/*.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "build": [
+        "./build/index.d.ts"
+      ],
+      "lib/*": [
+        "./lib/*.d.ts"
+      ],
+      "*": [
+        "This prevents imports of internal modules from compiling in TypeScript."
+      ]
+    }
+  },
   "files": [
     "bin/*",
     "bootstrap/*",


### PR DESCRIPTION
This PR makes the public API explicit using `exports` and `typesVersions` in `package.json`. This should enable us to reorganize internal modules, compile to a `dist` directory etc without having to release (or consider releasing) a new major version.

I haven't been able to figure out any way to make TypeScript find the index module (when our consumer does `import … from "userscripter"`), except keeping the `main` field as is.

This is a backward compatible change as long as our consumer doesn't import anything from `bootstrap/` or `build/internal/`. That has never been intended to work, and it seems unlikely to me that anyone will have done that and expected it to be stable.