### PR TITLE
ci: Install packed tarball instead of directory

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,9 +37,13 @@ jobs:
           npm run build
         env:
           CI: true
+      - name: Pack
+        id: pack
+        run: |
+          echo "::set-output name=tarball::$(pwd)/$(npm pack)"
       - name: Install CLI tool
         run: |
-          npm install --global .
+          npm install --global "${{ steps.pack.outputs.tarball }}"
       - name: Bootstrap userscript
         working-directory: ${{ runner.temp }}
         run: |


### PR DESCRIPTION
The tarball is more representative of what we actually ship.