### PR TITLE
chore: v3.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "userscripter",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "userscripter",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userscripter",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Create userscripts in a breeze!",
   "keywords": [
     "userscript",


### PR DESCRIPTION
This release makes imports from `bootstrap/` and/or `build/internal/` (which have never been intended to work) TypeScript compilation errors (#105).