### PR TITLE
chore: Remove unused loader-utils dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@types/fs-extra": "^8.0.1",
         "@types/json-schema": "^7.0.3",
-        "@types/loader-utils": "^1.1.3",
         "@types/node": "^12.12.8",
         "@types/sass": "^1.16.0",
         "@types/terser-webpack-plugin": "^2.2.0",
@@ -20,7 +19,6 @@
         "css-loader": "^3.2.0",
         "fs-extra": "^8.1.0",
         "lines-unlines": "^1.0.0",
-        "loader-utils": "^1.2.3",
         "node-sass-utils": "^1.1.3",
         "raw-loader": "^4.0.0",
         "sass": "^1.32.8",
@@ -698,15 +696,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
-    },
-    "node_modules/@types/loader-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/loader-utils/-/loader-utils-1.1.3.tgz",
-      "integrity": "sha512-euKGFr2oCB3ASBwG39CYJMR3N9T0nanVqXdiH7Zu/Nqddt6SmFRxytq/i2w9LQYNQekEtGBz+pE3qG6fQTNvRg==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webpack": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "12.12.8",
@@ -12088,15 +12077,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
-    },
-    "@types/loader-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@types/loader-utils/-/loader-utils-1.1.3.tgz",
-      "integrity": "sha512-euKGFr2oCB3ASBwG39CYJMR3N9T0nanVqXdiH7Zu/Nqddt6SmFRxytq/i2w9LQYNQekEtGBz+pE3qG6fQTNvRg==",
-      "requires": {
-        "@types/node": "*",
-        "@types/webpack": "*"
-      }
     },
     "@types/node": {
       "version": "12.12.8",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
   "dependencies": {
     "@types/fs-extra": "^8.0.1",
     "@types/json-schema": "^7.0.3",
-    "@types/loader-utils": "^1.1.3",
     "@types/node": "^12.12.8",
     "@types/sass": "^1.16.0",
     "@types/terser-webpack-plugin": "^2.2.0",
@@ -114,7 +113,6 @@
     "css-loader": "^3.2.0",
     "fs-extra": "^8.1.0",
     "lines-unlines": "^1.0.0",
-    "loader-utils": "^1.2.3",
     "node-sass-utils": "^1.1.3",
     "raw-loader": "^4.0.0",
     "sass": "^1.32.8",


### PR DESCRIPTION
I haven't been able to figure out why, or even if, we've ever actually needed it. For example, SimonAlling/better-sweclockers@b996a2b builds with Userscripter 1.0.0 with `loader-utils` and `@types/loader-utils` removed.