### PR TITLE
chore: Remove unused schema-utils dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "raw-loader": "^4.0.0",
         "sass": "^1.32.8",
         "sass-loader": "10.1.1",
-        "schema-utils": "^2.5.0",
         "terser-webpack-plugin": "^2.3.1",
         "to-string-loader": "^1.1.6",
         "ts-loader": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "raw-loader": "^4.0.0",
     "sass": "^1.32.8",
     "sass-loader": "10.1.1",
-    "schema-utils": "^2.5.0",
     "terser-webpack-plugin": "^2.3.1",
     "to-string-loader": "^1.1.6",
     "ts-loader": "^8.4.0",


### PR DESCRIPTION
I haven't been able to figure out why, or even if, we've ever actually needed it. For example, SimonAlling/better-sweclockers@b996a2b builds with Userscripter 1.0.0 with `schema-utils` removed.