### PR TITLE
chore: v3.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "userscripter",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "userscripter",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userscripter",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Create userscripts in a breeze!",
   "keywords": [
     "userscript",


### PR DESCRIPTION
This release removes the `@types/loader-utils`, `loader-utils` and `schema-utils` dependencies, which seemingly aren't used for anything at all (#109, #110).