### PR TITLE
build: Improve 'verify' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "rename": "renamer --force --find \"/\\.js$/\" --replace \".mjs\" \"lib/**\" \"build/**\"",
     "test": "npm run lint && npm run jest",
     "jest": "jest",
-    "verify": "repository-check-dirty && npm ci && npm run build && npm test && npm pack"
+    "verify": "npm ci && repository-check-dirty && npm run build && npm test && npm pack"
   },
   "sideEffects": false,
   "jest": {


### PR DESCRIPTION
Today, it fails like this after `git clean -xdf`:

    sh: 1: repository-check-dirty: not found

💡 `git show --color-words='npm ci|.'`