### PR TITLE
build: Specify rootDir explicitly

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
         "noUnusedParameters": true,
         "outDir": ".",
         "removeComments": true,
+        "rootDir": "src",
         "strict": true,
         "target": "es2018",
     },


### PR DESCRIPTION
It is implicitly `src` today, but that's because [it defaults to "the longest common path of all non-declaration input files"][docs].

[docs]: https://www.typescriptlang.org/tsconfig/#rootDir