### PR TITLE
chore: Remove unused @types/json-schema dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^8.0.1",
-        "@types/json-schema": "^7.0.3",
         "@types/node": "^12.12.8",
         "@types/sass": "^1.16.0",
         "@types/terser-webpack-plugin": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
   },
   "dependencies": {
     "@types/fs-extra": "^8.0.1",
-    "@types/json-schema": "^7.0.3",
     "@types/node": "^12.12.8",
     "@types/sass": "^1.16.0",
     "@types/terser-webpack-plugin": "^2.2.0",


### PR DESCRIPTION
I haven't been able to figure out why, or even if, we've ever actually needed it. For example, SimonAlling/better-sweclockers@b996a2b builds with Userscripter 1.0.0 with `@types/json-schema` removed.