### PR TITLE
fix: Use version 16 of @types/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^8.0.1",
-        "@types/node": "^12.12.8",
+        "@types/node": "^16.18.102",
         "@types/sass": "^1.16.0",
         "@types/terser-webpack-plugin": "^2.2.0",
         "@types/webpack": "^4.39.9",
@@ -696,9 +696,9 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "node_modules/@types/node": {
-      "version": "12.12.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.8.tgz",
-      "integrity": "sha512-XLla8N+iyfjvsa0KKV+BP/iGSoTmwxsu5Ci5sM33z9TjohF72DEz95iNvD6pPmemvbQgxAv/909G73gUn8QR7w=="
+      "version": "16.18.102",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.102.tgz",
+      "integrity": "sha512-eSe2YwGCcRjqPidxfm20IAq02krERWcIIJW4FNPkU0zQLbc4L9pvhsmB0p6UJecjEf0j/E2ERHsKq7madvthKw=="
     },
     "node_modules/@types/sass": {
       "version": "1.16.0",
@@ -12077,9 +12077,9 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@types/node": {
-      "version": "12.12.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.8.tgz",
-      "integrity": "sha512-XLla8N+iyfjvsa0KKV+BP/iGSoTmwxsu5Ci5sM33z9TjohF72DEz95iNvD6pPmemvbQgxAv/909G73gUn8QR7w=="
+      "version": "16.18.102",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.102.tgz",
+      "integrity": "sha512-eSe2YwGCcRjqPidxfm20IAq02krERWcIIJW4FNPkU0zQLbc4L9pvhsmB0p6UJecjEf0j/E2ERHsKq7madvthKw=="
     },
     "@types/sass": {
       "version": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@types/fs-extra": "^8.0.1",
-    "@types/node": "^12.12.8",
+    "@types/node": "^16.18.102",
     "@types/sass": "^1.16.0",
     "@types/terser-webpack-plugin": "^2.2.0",
     "@types/webpack": "^4.39.9",


### PR DESCRIPTION
We dropped support for Node 12 in #81 and have exclusively targeted Node 16 in CI since #85.