### PR TITLE
chore: Add /bin/ to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 # Compiled files:
+/bin/
 /build/
 /lib/


### PR DESCRIPTION
The reason it works without it is that the sole `.ts` file created in `bin/` by `npm run build` contains nothing more than this:

    #!/usr/bin/env node
    export {};

So it basically just happens to pass our ESLint config. But it makes sense to ignore all compiled files.