### PR TITLE
chore: Remove unused Prettier dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "eslint": "^7.25.0",
         "eslint-plugin-import": "^2.22.1",
         "jest": "^24.9.0",
-        "prettier": "^1.19.1",
         "renamer": "^1.1.4",
         "repository-check-dirty": "^1.0.2",
         "rimraf": "5.0.7",
@@ -8802,18 +8801,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/pretty-format": {
@@ -19044,12 +19031,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
-    "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "eslint": "^7.25.0",
     "eslint-plugin-import": "^2.22.1",
     "jest": "^24.9.0",
-    "prettier": "^1.19.1",
     "renamer": "^1.1.4",
     "repository-check-dirty": "^1.0.2",
     "rimraf": "5.0.7",


### PR DESCRIPTION
As far as I can tell, it has never been used for anything, except perhaps in an ad-hoc way. Since we don't use Prettier to check code formatting as part of any script or similar, I don't think it belongs as a dev dependency.