### PR TITLE
ci: Use $GITHUB_OUTPUT instead of set-output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Pack
         id: pack
         run: |
-          echo "::set-output name=tarball::$(pwd)/$(npm pack)"
+          echo "tarball=$(pwd)/$(npm pack)" >> $GITHUB_OUTPUT
       - name: Install CLI tool
         run: |
           npm install --global "${{ steps.pack.outputs.tarball }}"
@@ -77,7 +77,7 @@ jobs:
       - name: Pack
         id: pack
         run: |
-          echo "::set-output name=tarball::$(pwd)/$(npm pack)"
+          echo "tarball=$(pwd)/$(npm pack)" >> $GITHUB_OUTPUT
       - name: Clone userscript
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
We're getting this warning in CI, in the Pack steps:

> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Also, from now on, we won't be hard-wrapping commit messages at 72 characters anymore. I've changed the _Default commit message_ setting for the repository from _Pull request title and description_ to _Pull request title_; the description must be manually copied and pasted when merging because, unlike Azure DevOps, GitHub doesn't support using the description without hard-wrapping it.

💡 `git show --color-words=.`