### PR TITLE
chore: v3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "userscripter",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "userscripter",
-      "version": "3.0.5",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userscripter",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "description": "Create userscripts in a breeze!",
   "keywords": [
     "userscript",


### PR DESCRIPTION
This release makes `userscripter init` bootstrap a userscript that uses version 2.0.0 of Userscripter.