### PR TITLE
ci: Clone repos shallowly (`fetch-depth: 1`)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,9 @@ jobs:
       matrix:
         node-version: [16.x]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -63,7 +65,9 @@ jobs:
         node-version: [16.x]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -83,6 +87,7 @@ jobs:
         with:
           repository: ${{ matrix.repository }}
           path: dependent-userscripts/${{ matrix.repository }} # Must be relative to github.workspace, apparently.
+          fetch-depth: 1
       - name: Move userscript
         run: |
           mkdir -p "${TARGET_DIR}"


### PR DESCRIPTION
The `fetch-depth` input seems to have been introduced in v2.

💡 `git show --color-words='v1|.'`