### PR TITLE
chore: v4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "userscripter",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "userscripter",
-      "version": "3.2.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/sass": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userscripter",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "Create userscripts in a breeze!",
   "keywords": [
     "userscript",


### PR DESCRIPTION
This release removes the CLI tool used to create new userscripts. It shouldn't be breaking for existing userscripts, unless they `import … from "userscripter/bootstrap/…"` (which has never been intended to work; see #108) or run `userscripter init` for whatever reason.

## Migration guide

Any invocations of `userscripter init` need to be replaced with a `tiged` command; see `README.md`.