### PR TITLE
ci: Pin Ubuntu version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   nightly:
     name: CI Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [16.x]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   nightly:
     name: CI Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [16.x]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   nightly:
     name: CI Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [16.x]
@@ -49,7 +49,7 @@ jobs:
           npm run build
   userscripts:
     name: Dependent Userscripts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         repository:


### PR DESCRIPTION
Having CI suddenly break because a new version of Ubuntu has been released or whatever _sucks_. The more deterministic the builds, the better.

I chose 22.04 because we implicitly use that today (log says 22.04.4).