### PR TITLE
ci: Pin Node version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.20.2]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -55,7 +55,7 @@ jobs:
         repository:
           - SimonAlling/better-sweclockers
           - SimonAlling/example-userscript
-        node-version: [16.x]
+        node-version: [16.20.2]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Having CI suddenly break because a new version of Node has been released or whatever _sucks_. The more deterministic the builds, the better.
    
I chose 16.20.2 because we implicitly use that today, according to the log.

In addition to the changes in this PR, I had to go to [the branch protection rule for `master`][rule] and replace **CI Build (16.x)** with **CI Build (16.20.2)** under _Require status checks to pass before merging_.

This PR is similar to #135.

[rule]: https://github.com/SimonAlling/userscripter/settings/branch_protection_rules/17488390