### PR TITLE
ci: Check bootstrapped userscript in its own job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,13 @@ jobs:
       matrix:
         node-version: [16.20.2]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: Bootstrap userscript
         # This step is NOT intended to check how any changes to the library/package might affect the bootstrapped userscript.
         # It only checks changes to the bootstrapped userscript itself.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,16 @@ jobs:
           npm run build
         env:
           CI: true
+  bootstrap:
+    name: Bootstrapped Userscript
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        node-version: [16.20.2]
+    steps:
       - name: Bootstrap userscript
+        # This step is NOT intended to check how any changes to the library/package might affect the bootstrapped userscript.
+        # It only checks changes to the bootstrapped userscript itself.
         working-directory: ${{ runner.temp }}
         run: |
           mkdir bootstrapped-userscript


### PR DESCRIPTION
The current implementation may give the impression that checking the bootstrapped userscript somehow depends on checking and building the package first, but that's not the case.

In addition to the changes in this PR, I had to go to [the branch protection rule for `master`][rule] and add **Bootstrapped Userscript (16.20.2)** under _Require status checks to pass before merging_.

[rule]: https://github.com/SimonAlling/userscripter/settings/branch_protection_rules/17488390