### PR TITLE
ci: Make bootstrapped userscript dependent

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
           npm ci
           npm run build
   userscripts:
-    name: Dependent Userscripts – ${{ matrix.repository.humanReadableName }} @ ${{ matrix.repository.refInRepo }}
+    name: Dependent: ${{ matrix.repository.humanReadableName }} @ ${{ matrix.repository.refInRepo }} (Node ${{ matrix.node-version }})
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
             pathInRepo: ""
           - humanReadableName: Bootstrapped Userscript
             ownerSlashName: SimonAlling/userscripter
-            refInRepo: ${{ github.sha }}
+            refInRepo: ${{ github.sha }} # The purpose here, unlike in the `bootstrap` job, _is_ to check how any changes to the library/package might affect the bootstrapped userscript.
             pathInRepo: bootstrap/
         node-version: [16.20.2]
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,8 +69,15 @@ jobs:
     strategy:
       matrix:
         repository:
-          - SimonAlling/better-sweclockers
-          - SimonAlling/example-userscript
+          - ownerSlashName: SimonAlling/better-sweclockers
+            refInRepo: master
+            pathInRepo: ""
+          - ownerSlashName: SimonAlling/example-userscript
+            refInRepo: master
+            pathInRepo: ""
+          - ownerSlashName: SimonAlling/userscripter
+            refInRepo: ${{ github.sha }}
+            pathInRepo: bootstrap/
         node-version: [16.20.2]
       fail-fast: false
     steps:
@@ -94,24 +101,25 @@ jobs:
       - name: Clone userscript
         uses: actions/checkout@v2
         with:
-          repository: ${{ matrix.repository }}
-          path: dependent-userscripts/${{ matrix.repository }} # Must be relative to github.workspace, apparently.
+          repository: ${{ matrix.repository.ownerSlashName }}
+          ref: ${{ matrix.repository.refInRepo }}
+          path: dependent-userscripts/${{ matrix.repository.ownerSlashName }} # Must be relative to github.workspace, apparently.
           fetch-depth: 1
       - name: Move userscript
         run: |
           mkdir -p "${TARGET_DIR}"
-          mv --no-target-directory "${{ github.workspace }}/dependent-userscripts/${{ matrix.repository }}" "${TARGET_DIR}"
+          mv --no-target-directory "${{ github.workspace }}/dependent-userscripts/${{ matrix.repository.ownerSlashName }}" "${TARGET_DIR}"
         env:
-          TARGET_DIR: ${{ runner.temp }}/${{ matrix.repository }}
+          TARGET_DIR: ${{ runner.temp }}/${{ matrix.repository.ownerSlashName }}
       - name: Install userscript dependencies
-        working-directory: ${{ runner.temp }}/${{ matrix.repository }}
+        working-directory: ${{ runner.temp }}/${{ matrix.repository.ownerSlashName }}/${{ matrix.repository.pathInRepo }}
         run: |
           npm ci
       - name: Install Userscripter
-        working-directory: ${{ runner.temp }}/${{ matrix.repository }}
+        working-directory: ${{ runner.temp }}/${{ matrix.repository.ownerSlashName }}/${{ matrix.repository.pathInRepo }}
         run: |
           npm install "${{ steps.pack.outputs.tarball }}"
       - name: Build userscript
-        working-directory: ${{ runner.temp }}/${{ matrix.repository }}
+        working-directory: ${{ runner.temp }}/${{ matrix.repository.ownerSlashName }}/${{ matrix.repository.pathInRepo }}
         run: |
           npm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
             ownerSlashName: SimonAlling/example-userscript
             refInRepo: master
             pathInRepo: ""
-          - humanReadableName: Bootstrapped userscript
+          - humanReadableName: Bootstrapped Userscript
             ownerSlashName: SimonAlling/userscripter
             refInRepo: ${{ github.sha }}
             pathInRepo: bootstrap/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,18 +64,21 @@ jobs:
           npm ci
           npm run build
   userscripts:
-    name: Dependent Userscripts
+    name: Dependent Userscripts – ${{ matrix.repository.humanReadableName }} @ ${{ matrix.repository.refInRepo }}
     runs-on: ubuntu-22.04
     strategy:
       matrix:
         repository:
-          - ownerSlashName: SimonAlling/better-sweclockers
+          - humanReadableName: Better SweClockers
+            ownerSlashName: SimonAlling/better-sweclockers
             refInRepo: master
             pathInRepo: ""
-          - ownerSlashName: SimonAlling/example-userscript
+          - humanReadableName: Example Userscript
+            ownerSlashName: SimonAlling/example-userscript
             refInRepo: master
             pathInRepo: ""
-          - ownerSlashName: SimonAlling/userscripter
+          - humanReadableName: Bootstrapped userscript
+            ownerSlashName: SimonAlling/userscripter
             refInRepo: ${{ github.sha }}
             pathInRepo: bootstrap/
         node-version: [16.20.2]


### PR DESCRIPTION
The `bootstrap` job doesn't check how any changes to the library/package might affect the bootstrapped userscript; it only checks changes to the bootstrapped userscript itself (i.e. in `bootstrap/`). But we do want to know if a PR breaks the bootstrapped userscript, because then the PR may need to be considered breaking.

This PR therefore makes the bootstrapped userscript a so-called dependent userscript, just like Better SweClockers and Example Userscript. Building dependent userscripts deliberately isn't a _gating_ check because, as previously explained in #68, the purpose isn't to prevent _deliberate_ breaking changes, just _accidental_ ones.

💡 `git show --color-words=.`