### PR TITLE
docs: Update bootstrapped userscript post-release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -58,6 +58,9 @@
 
 These steps aren't strictly necessary, but it typically makes sense for the bootstrapped userscript to use the latest version of the package.
 
+> [!IMPORTANT]
+> This can only be done if a new version of the package was successfully published in the previous section.
+
   1. Install the newly published version in the bootstrapped userscript:
 
      ```bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
 # Release workflow
 
+## Release a new version of the npm package
+
   1. Get up to date:
 
      ```bash
@@ -51,3 +53,37 @@
      ```bash
      git clean -xdf && npm publish # `npm publish` should automatically build first (see `prepublishOnly` script).
      ```
+
+## Update the bootstrapped userscript
+
+These steps aren't strictly necessary, but it typically makes sense for the bootstrapped userscript to use the latest version of the package.
+
+  1. Install the newly published version in the bootstrapped userscript:
+
+     ```bash
+     cd "$(git rev-parse --show-toplevel)/bootstrap"
+     git clean -xdf .
+     THE_BOOTSTRAP_BRANCH="bootstrap-${THE_VERSION:?}"
+     git switch --create "${THE_BOOTSTRAP_BRANCH:?}"
+     npm ci
+     npm install -E "userscripter@${THE_VERSION:?}"
+     git add package*.json
+     npm run build
+     ```
+
+  1. Modify the bootstrapped userscript if necessary, then stage the changes:
+
+     ```bash
+     git add -p
+     ```
+
+  1. Commit and push:
+
+     ```bash
+     git commit -m "chore: Use ${THE_VERSION:?} in bootstrapped userscript"
+     git push -u origin "${THE_BOOTSTRAP_BRANCH:?}"
+     ```
+
+  1. Create a PR based on the newly pushed branch.
+
+  1. Review and merge the PR.


### PR DESCRIPTION
I used this workflow in #140. It ensures that the recommended way of bootstrapping a new userscript (the `tiged` command in `README.md`) will always work, including when a release PR has been merged but a corresponding version of the package hasn't been published to the npm registry (either because it hasn't been done yet or because it cannot be done at all for whatever reason).