### PR TITLE
docs: Hotfix broken warning alert

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@
 
   1. Create a PR based on the newly pushed branch.
 
-     > [!WARNING]
+     > ⚠️ **Warning**
      >
      > The PR description should include a brief summary of the user-facing changes included in the release.
      >

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@
 
   1. Create a PR based on the newly pushed branch.
 
-     > ⚠️ **Warning**
+     > ⚠️ **Warning** <!-- Change to [!WARNING] when possible (see #142). -->
      >
      > The PR description should include a brief summary of the user-facing changes included in the release.
      >


### PR DESCRIPTION
When viewing the file on GitHub, it's rendered as if `[!WARNING]` doesn't have any special meaning at all. Turns out [alerts cannot be indented], so I guess this is the best we can do for now.

[alerts cannot be indented]: https://github.com/orgs/community/discussions/118296