### PR TITLE
build: Pin TypeScript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "rimraf": "5.0.7",
         "ts-jest": "^24.1.0",
         "ts-preferences": "^2.0.0",
-        "typescript": "^4.2.3"
+        "typescript": "4.2.3"
       },
       "peerDependencies": {
         "ts-preferences": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "rimraf": "5.0.7",
     "ts-jest": "^24.1.0",
     "ts-preferences": "^2.0.0",
-    "typescript": "^4.2.3"
+    "typescript": "4.2.3"
   },
   "peerDependencies": {
     "ts-preferences": "^2.0.0"


### PR DESCRIPTION
TypeScript doesn't use SemVer – one should think of e.g. v4.2 and v4.3 as v42 and v43, respectively – so `^4.2.3` makes no sense. `~4.2.3` does, but it usually doesn't hurt to specify an exact version in my experience.