### PR TITLE
build: Upgrade to TypeScript 4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "rimraf": "5.0.7",
         "ts-jest": "^24.1.0",
         "ts-preferences": "^2.0.0",
-        "typescript": "4.3.5"
+        "typescript": "4.4.4"
       },
       "peerDependencies": {
         "ts-preferences": "^2.0.0"
@@ -11053,9 +11053,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20601,9 +20601,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA=="
     },
     "typical": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "rimraf": "5.0.7",
     "ts-jest": "^24.1.0",
     "ts-preferences": "^2.0.0",
-    "typescript": "4.3.5"
+    "typescript": "4.4.4"
   },
   "peerDependencies": {
     "ts-preferences": "^2.0.0"


### PR DESCRIPTION
This will enable upgrading to Jest 26 (#144; see #145).

## Breaking?

See #145 for details on why this should possibly be considered a breaking change.

I consider it backward compatible, because I don't think any consumer is broken by it. Notably, building with and without this PR in different Git working trees and using `git diff --no-index` to diff the emitted code (`build/` and `lib/`) reveals that the only difference is that some expressions in `.js` files are transformed from `foo` to `(0, foo)`.