### PR TITLE
build: Move Jest configuration to its own file

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,0 +1,11 @@
+export default {
+  "testEnvironment": "jsdom",
+  "transform": {
+    "^.+\\.ts$": "ts-jest"
+  },
+  "testRegex": ".+\\.test\\.ts$",
+  "moduleFileExtensions": [
+    "ts",
+    "js"
+  ]
+};

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,11 +1,11 @@
 export default {
   "testEnvironment": "jsdom",
   "transform": {
-    "^.+\\.ts$": "ts-jest"
+    "^.+\\.ts$": "ts-jest",
   },
   "testRegex": ".+\\.test\\.ts$",
   "moduleFileExtensions": [
     "ts",
-    "js"
-  ]
+    "js",
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -65,21 +65,10 @@
     "prepublishOnly": "npm run verify && cli-confirm 'Publish?'",
     "rename": "renamer --force --find \"/\\.js$/\" --replace \".mjs\" \"lib/**\" \"build/**\"",
     "test": "npm run lint && npm run jest",
-    "jest": "jest",
+    "jest": "jest --config ./jest.config.mjs",
     "verify": "npm ci && repository-check-dirty && npm run build && npm test && npm pack"
   },
   "sideEffects": false,
-  "jest": {
-    "testEnvironment": "jsdom",
-    "transform": {
-      "^.+\\.ts$": "ts-jest"
-    },
-    "testRegex": ".+\\.test\\.ts$",
-    "moduleFileExtensions": [
-      "ts",
-      "js"
-    ]
-  },
   "devDependencies": {
     "@types/jest": "27.5.2",
     "@typescript-eslint/eslint-plugin": "^4.22.0",


### PR DESCRIPTION
Specifying the file with `--config` isn't necessary, but I like to be explicit.

💡 `git show --color-moved --color-moved-ws=allow-indentation-change`