### PR TITLE
test: Use async/await instead of 'done' callback

### DIFF
--- a/__tests__/api.test.ts
+++ b/__tests__/api.test.ts
@@ -27,22 +27,19 @@ it("exposes the intended API", () => {
   expect(stylesheets.disable).toBeDefined();
 });
 
-it("exposes everything in lib in index.ts", done => {
-  fs.readdir(path.resolve(__dirname, "..", "src", "lib"), (err, filenames) => {
-    expect(err).toBeNull();
-    expect(filenames).toEqual([
-      "environment.ts",
-      "errors.ts",
-      "index.ts",
-      "log.ts",
-      "operations.ts",
-      "preferences.ts",
-      "stylesheets.ts",
-      "userscripter.ts",
-    ]);
-    const modulesThatAreExported = Object.keys(index);
-    const modulesThatShouldBeExported = filenames.map(n => n.replace(/\.ts$/, "")).filter(n => n !== "index");
-    expect(modulesThatAreExported).toEqual(modulesThatShouldBeExported);
-    done();
-  });
+it("exposes everything in lib in index.ts", async () => {
+  const filenames = await fs.promises.readdir(path.resolve(__dirname, "..", "src", "lib"));
+  expect(filenames).toEqual([
+    "environment.ts",
+    "errors.ts",
+    "index.ts",
+    "log.ts",
+    "operations.ts",
+    "preferences.ts",
+    "stylesheets.ts",
+    "userscripter.ts",
+  ]);
+  const modulesThatAreExported = Object.keys(index);
+  const modulesThatShouldBeExported = filenames.map(n => n.replace(/\.ts$/, "")).filter(n => n !== "index");
+  expect(modulesThatAreExported).toEqual(modulesThatShouldBeExported);
 });


### PR DESCRIPTION
With Jest 27 (#147), the `exposes everything in lib in index.ts` test case started behaving weirdly in situations when it should fail. For example, creating `src/lib/foo.ts` causes `npm test` to fail like this after about 10 seconds (which is longer than usual):

      ● exposes everything in lib in index.ts

        expect(received).toEqual(expected) // deep equality

        - Expected  - 0
        + Received  + 1

        @@ -1,8 +1,9 @@
          Array [
            "environment.ts",
            "errors.ts",
        +   "foo.ts",
            "index.ts",
            "log.ts",
            "operations.ts",
            "preferences.ts",
            "stylesheets.ts",

    […]

      ● exposes everything in lib in index.ts

        thrown: "Exceeded timeout of 5000 ms for a test.
        Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."

The `expect` failure is expected, but the timeout is unexpected and doesn't happen with Jest 26. I have no idea why it does with Jest 27, but this PR fixes the issue by using `async`/`await` and `fs.promises` instead of a `done` callback.

💡 `git show --ignore-space-change --color-words='\w+|.'`