### PR TITLE
chore: v5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "userscripter",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "userscripter",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/sass": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userscripter",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Create userscripts in a breeze!",
   "keywords": [
     "userscript",


### PR DESCRIPTION
This release renames the `build` and `lib` export paths to `build-time` and `run-time`, respectively (#104).

## Migration guide

You need to adapt your imports like this:

  * ```diff
    -import … from "userscripter/build";
    +import … from "userscripter/build-time";
    ```

  * ```diff
    -import … from "userscripter/lib/foo";
    +import … from "userscripter/run-time/foo";
    ```

This command should accomplish that in a typical Git-tracked userscript:

```bash
for f in $(git ls-files "$(git rev-parse --show-toplevel)"); do
  sed -i 's#userscripter/build#userscripter/build-time#g' $f
  sed -i 's#userscripter/lib#userscripter/run-time#g' $f
done
```