### PR TITLE
chore: Use v5.0.0 in bootstrapped userscript

### DIFF
--- a/bootstrap/metadata.ts
+++ b/bootstrap/metadata.ts
@@ -1,7 +1,7 @@
 import { Metadata } from "userscript-metadata";
 import {
     BuildConfig,
-} from "userscripter/build";
+} from "userscripter/build-time";
 
 import U from "./src/userscript";
 

--- a/bootstrap/package-lock.json
+++ b/bootstrap/package-lock.json
@@ -12,7 +12,7 @@
         "ts-preferences": "^2.0.0",
         "typescript": "^3.7.4",
         "userscript-metadata": "^1.0.0",
-        "userscripter": "4.0.0",
+        "userscripter": "5.0.0",
         "webpack": "^4.41.5",
         "webpack-cli": "^3.3.10"
       }
@@ -4679,9 +4679,9 @@
       }
     },
     "node_modules/userscripter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-4.0.0.tgz",
-      "integrity": "sha512-KHdpe173p179cAYURkI1G251jxjhF7tTLX74TfRGRKL0MWqR2N+YpMDd5dUxqk2cU6aVv85igswEohPRsgD2cg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-5.0.0.tgz",
+      "integrity": "sha512-lIvXdu16SFu3UqhfgincC6FPGsIxx7CW27ZAGkKfneYkqgOswEuJleI6R76d2M+C9vHNL/OibGpJktkuQak0mA==",
       "dependencies": {
         "@types/sass": "^1.16.0",
         "@types/terser-webpack-plugin": "^2.2.0",
@@ -8962,9 +8962,9 @@
       }
     },
     "userscripter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-4.0.0.tgz",
-      "integrity": "sha512-KHdpe173p179cAYURkI1G251jxjhF7tTLX74TfRGRKL0MWqR2N+YpMDd5dUxqk2cU6aVv85igswEohPRsgD2cg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-5.0.0.tgz",
+      "integrity": "sha512-lIvXdu16SFu3UqhfgincC6FPGsIxx7CW27ZAGkKfneYkqgOswEuJleI6R76d2M+C9vHNL/OibGpJktkuQak0mA==",
       "requires": {
         "@types/sass": "^1.16.0",
         "@types/terser-webpack-plugin": "^2.2.0",

--- a/bootstrap/package.json
+++ b/bootstrap/package.json
@@ -14,7 +14,7 @@
     "ts-preferences": "^2.0.0",
     "typescript": "^3.7.4",
     "userscript-metadata": "^1.0.0",
-    "userscripter": "4.0.0",
+    "userscripter": "5.0.0",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10"
   }

--- a/bootstrap/src/operations.ts
+++ b/bootstrap/src/operations.ts
@@ -1,4 +1,4 @@
-import { Operation, operation } from "userscripter/lib/operations";
+import { Operation, operation } from "userscripter/run-time/operations";
 
 const OPERATIONS: ReadonlyArray<Operation<any>> = [
 ];

--- a/bootstrap/src/preferences.ts
+++ b/bootstrap/src/preferences.ts
@@ -1,7 +1,7 @@
 import {
     PreferenceManager,
 } from "ts-preferences";
-import { loggingResponseHandler } from "userscripter/lib/preferences";
+import { loggingResponseHandler } from "userscripter/run-time/preferences";
 
 import U from "~src/userscript";
 

--- a/bootstrap/src/stylesheets.ts
+++ b/bootstrap/src/stylesheets.ts
@@ -1,5 +1,5 @@
-import { ALWAYS } from "userscripter/lib/environment";
-import { Stylesheets, stylesheet } from "userscripter/lib/stylesheets";
+import { ALWAYS } from "userscripter/run-time/environment";
+import { Stylesheets, stylesheet } from "userscripter/run-time/stylesheets";
 
 const STYLESHEETS = {
     main: stylesheet({

--- a/bootstrap/webpack.config.ts
+++ b/bootstrap/webpack.config.ts
@@ -3,7 +3,7 @@ import {
     createWebpackConfig,
     DEFAULT_BUILD_CONFIG,
     DEFAULT_METADATA_SCHEMA,
-} from "userscripter/build";
+} from "userscripter/build-time";
 
 import METADATA from "./metadata";
 import * as CONFIG from "./src/config";


### PR DESCRIPTION
I used the command suggested in #153 to adapt the source code.

💡 `git show --color-words='build-time|(\w|\+|=)+|.'`