### PR TITLE
chore: Use TypeScript 4.5 in bootstrapped userscript

### DIFF
--- a/bootstrap/package-lock.json
+++ b/bootstrap/package-lock.json
@@ -10,7 +10,7 @@
         "app-root-path": "^3.0.0",
         "rimraf": "^3.0.2",
         "ts-preferences": "^2.0.0",
-        "typescript": "^3.7.4",
+        "typescript": "4.5.5",
         "userscript-metadata": "^1.0.0",
         "userscripter": "5.0.0",
         "webpack": "^4.41.5",
@@ -4529,9 +4529,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8837,9 +8837,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/bootstrap/package.json
+++ b/bootstrap/package.json
@@ -12,7 +12,7 @@
     "app-root-path": "^3.0.0",
     "rimraf": "^3.0.2",
     "ts-preferences": "^2.0.0",
-    "typescript": "^3.7.4",
+    "typescript": "4.5.5",
     "userscript-metadata": "^1.0.0",
     "userscripter": "5.0.0",
     "webpack": "^4.41.5",


### PR DESCRIPTION
We use TypeScript 4.5 to compile the package itself since #151 (v5.0.0), so it makes sense to use at least that version in the bootstrapped userscript as well.

I did `npm install --save-exact typescript@4.5` because it typically makes much more sense to specify an exact TypeScript version than to specify a version range.