### PR TITLE
chore: Remove unnecessary @types dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
-        "@types/sass": "^1.16.0",
-        "@types/terser-webpack-plugin": "^2.2.0",
         "@types/webpack": "^4.39.9",
         "css-loader": "^3.2.0",
         "lines-unlines": "^1.0.0",
@@ -29,6 +27,8 @@
       },
       "devDependencies": {
         "@types/jest": "29.5.12",
+        "@types/sass": "1.16.0",
+        "@types/terser-webpack-plugin": "2.2.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "cli-confirm": "^1.0.1",
@@ -1883,6 +1883,7 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.16.0.tgz",
       "integrity": "sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1913,6 +1914,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/terser-webpack-plugin/-/terser-webpack-plugin-2.2.0.tgz",
       "integrity": "sha512-ywqEfTm7KdKoX9aYx0zYtiFU1z6IHrIYW9FJqeay2Ea58rTPML1J0hvoztGal2Jow3bkgGKcAmEZNL+8LqUVrA==",
+      "dev": true,
       "dependencies": {
         "@types/webpack": "*",
         "terser": "^4.3.9"
@@ -15497,6 +15499,7 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.16.0.tgz",
       "integrity": "sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -15527,6 +15530,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/terser-webpack-plugin/-/terser-webpack-plugin-2.2.0.tgz",
       "integrity": "sha512-ywqEfTm7KdKoX9aYx0zYtiFU1z6IHrIYW9FJqeay2Ea58rTPML1J0hvoztGal2Jow3bkgGKcAmEZNL+8LqUVrA==",
+      "dev": true,
       "requires": {
         "@types/webpack": "*",
         "terser": "^4.3.9"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
   "sideEffects": false,
   "devDependencies": {
     "@types/jest": "29.5.12",
+    "@types/sass": "1.16.0",
+    "@types/terser-webpack-plugin": "2.2.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "cli-confirm": "^1.0.1",
@@ -89,8 +91,6 @@
     "ts-preferences": "^2.0.0"
   },
   "dependencies": {
-    "@types/sass": "^1.16.0",
-    "@types/terser-webpack-plugin": "^2.2.0",
     "@types/webpack": "^4.39.9",
     "css-loader": "^3.2.0",
     "lines-unlines": "^1.0.0",


### PR DESCRIPTION
Typical userscripts probably don't need these dependencies because they don't import anything from the corresponding packages.