### PR TITLE
chore: Remove @types/terser-webpack-plugin dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/sass": "^1.16.0",
-        "@types/terser-webpack-plugin": "^2.2.0",
         "@types/webpack": "^4.39.9",
         "css-loader": "^3.2.0",
         "lines-unlines": "^1.0.0",
@@ -29,6 +28,7 @@
       },
       "devDependencies": {
         "@types/jest": "29.5.12",
+        "@types/terser-webpack-plugin": "2.2.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
         "cli-confirm": "^1.0.1",
@@ -1913,6 +1913,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/terser-webpack-plugin/-/terser-webpack-plugin-2.2.0.tgz",
       "integrity": "sha512-ywqEfTm7KdKoX9aYx0zYtiFU1z6IHrIYW9FJqeay2Ea58rTPML1J0hvoztGal2Jow3bkgGKcAmEZNL+8LqUVrA==",
+      "dev": true,
       "dependencies": {
         "@types/webpack": "*",
         "terser": "^4.3.9"
@@ -15527,6 +15528,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/terser-webpack-plugin/-/terser-webpack-plugin-2.2.0.tgz",
       "integrity": "sha512-ywqEfTm7KdKoX9aYx0zYtiFU1z6IHrIYW9FJqeay2Ea58rTPML1J0hvoztGal2Jow3bkgGKcAmEZNL+8LqUVrA==",
+      "dev": true,
       "requires": {
         "@types/webpack": "*",
         "terser": "^4.3.9"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "sideEffects": false,
   "devDependencies": {
     "@types/jest": "29.5.12",
+    "@types/terser-webpack-plugin": "2.2.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
     "cli-confirm": "^1.0.1",
@@ -90,7 +91,6 @@
   },
   "dependencies": {
     "@types/sass": "^1.16.0",
-    "@types/terser-webpack-plugin": "^2.2.0",
     "@types/webpack": "^4.39.9",
     "css-loader": "^3.2.0",
     "lines-unlines": "^1.0.0",


### PR DESCRIPTION
A typical userscript doesn't need it because it doesn't import anything from the `terser-webpack-plugin` package; I therefore consider this a backward-compatible change.

I did this:

    $ npm why @types/terser-webpack-plugin
    @types/terser-webpack-plugin@2.2.0
    node_modules/@types/terser-webpack-plugin
      @types/terser-webpack-plugin@"^2.2.0" from the root project

    $ npm remove @types/terser-webpack-plugin

    $ npm install --save-dev --save-exact @types/terser-webpack-plugin@2.2.0