### PR TITLE
refactor: Specify css-loader options

### DIFF
--- a/src/build-time/internal/webpack.ts
+++ b/src/build-time/internal/webpack.ts
@@ -153,8 +153,8 @@ export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configu
                                     exportGlobals: false,
                                     localIdentName: "[local]",
                                     context: undefined,
-                                    hashPrefix: "", // Documented default is undefined, but actual default is "" based on source code (v3.6.0).
-                                    // getLocalIdent: Documented default is undefined, but that is not allowed (v3.6.0).
+                                    hashPrefix: "", // Documented default is undefined, but actual default seems to be "" based on source code (in css-loader v3.6.0).
+                                    // getLocalIdent: Documented default is undefined, but that doesn't work (in css-loader v3.6.0).
                                     // localIdentRegExp: Documented default is undefined, but that is not allowed (v3.6.0).
                                 },
                                 importLoaders: 0,

--- a/src/build-time/internal/webpack.ts
+++ b/src/build-time/internal/webpack.ts
@@ -144,10 +144,23 @@ export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configu
                         {
                             loader: require.resolve("css-loader"),
                             options: {
+                                url: true,
+                                import: true,
                                 sourceMap: false,
                                 modules: {
+                                    auto: undefined,
+                                    mode: "local",
+                                    exportGlobals: false,
                                     localIdentName: "[local]",
+                                    context: undefined,
+                                    hashPrefix: "", // Documented default is undefined, but actual default is "" based on source code (v3.6.0).
+                                    // getLocalIdent: Documented default is undefined, but that is not allowed (v3.6.0).
+                                    // localIdentRegExp: Documented default is undefined, but that is not allowed (v3.6.0).
                                 },
+                                importLoaders: 0,
+                                localsConvention: "asIs",
+                                onlyLocals: false,
+                                esModule: false,
                             },
                         },
                         {

--- a/src/build-time/internal/webpack.ts
+++ b/src/build-time/internal/webpack.ts
@@ -155,7 +155,7 @@ export function createWebpackConfig(x: WebpackConfigParameters): webpack.Configu
                                     context: undefined,
                                     hashPrefix: "", // Documented default is undefined, but actual default seems to be "" based on source code (in css-loader v3.6.0).
                                     // getLocalIdent: Documented default is undefined, but that doesn't work (in css-loader v3.6.0).
-                                    // localIdentRegExp: Documented default is undefined, but that is not allowed (v3.6.0).
+                                    localIdentRegExp: undefined, // Documented default is undefined, but actual default seems to be null based on source code, but null is not allowed (in css-loader v3.6.0).
                                 },
                                 importLoaders: 0,
                                 localsConvention: "asIs",


### PR DESCRIPTION
I think this will make it easier to upgrade `css-loader`, which in turn I think will be necessary in order to upgrade to webpack 5.

At the time of writing, the latest version of `css-loader` that matches `^3.2.0` – and the one used in the bootstrapped userscript, SimonAlling/example-userscript@d1d30ea5 and SimonAlling/better-sweclockers@7381699f, according to `npm why` – is **3.6.0**. I went [here] to check what its default options are, and then I specified them. For some of them, the documented default value isn't obviously correct/sensible:

  * ### `hashPrefix`

    The documented default value is `undefined`, but based on [the source code][hashPrefix], it's actually `""`. That makes much more sense to me too.

  * ### `getLocalIdent`

    The documented default value is `undefined`, but specifying that causes consuming userscripts (e.g. SimonAlling/example-userscript@d1d30ea5) to fail to build with this error:

        TypeError: modulesOptions.getLocalIdent is not a function

  * ### `localIdentRegExp`

    The documented default value is `undefined`, but based on [the source code][localIdentRegExp], it's actually `null`. Specifying `null`, however, causes consuming userscripts (e.g. SimonAlling/example-userscript@d1d30ea5) to fail to build with this error:

        Details:
         * options.modules.localIdentRegExp should be one of these:
           string | RegExp
           Details:
            * options.modules.localIdentRegExp should be a string.
            * options.modules.localIdentRegExp should be an instance of RegExp.

[here]: https://github.com/webpack-contrib/css-loader/tree/v3.6.0
[hashPrefix]: https://github.com/webpack-contrib/css-loader/blob/v3.6.0/src/utils.js#L133
[localIdentRegExp]: https://github.com/webpack-contrib/css-loader/blob/v3.6.0/src/utils.js#L134