### PR TITLE
fix: Add @types/node@16.18.31 as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
+        "@types/node": "16.18.31",
         "@types/sass": "^1.16.0",
         "@types/webpack": "^4.41.38",
         "css-loader": "^3.2.0",
@@ -1870,9 +1871,10 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "node_modules/@types/node": {
-      "version": "12.12.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.8.tgz",
-      "integrity": "sha512-XLla8N+iyfjvsa0KKV+BP/iGSoTmwxsu5Ci5sM33z9TjohF72DEz95iNvD6pPmemvbQgxAv/909G73gUn8QR7w=="
+      "version": "16.18.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw==",
+      "license": "MIT"
     },
     "node_modules/@types/sass": {
       "version": "1.16.0",
@@ -15506,9 +15508,9 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@types/node": {
-      "version": "12.12.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.8.tgz",
-      "integrity": "sha512-XLla8N+iyfjvsa0KKV+BP/iGSoTmwxsu5Ci5sM33z9TjohF72DEz95iNvD6pPmemvbQgxAv/909G73gUn8QR7w=="
+      "version": "16.18.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
+      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw=="
     },
     "@types/sass": {
       "version": "1.16.0",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "ts-preferences": "^2.0.0"
   },
   "dependencies": {
+    "@types/node": "16.18.31",
     "@types/sass": "^1.16.0",
     "@types/webpack": "^4.41.38",
     "css-loader": "^3.2.0",


### PR DESCRIPTION
Yeah, how does one even document this …

## Problem

When I recently returned to this project after not having touched it since 2024-08-01 (#161), suddenly CI would fail, without any changes having been made. The failure happened in the **Dependent: Bootstrapped Userscript (Node 16.20.2)** job, in the **Build userscript** step:

    > build-webpack-config
    > tsc -p tsconfig.webpack.json

    Error: node_modules/@types/node/http.d.ts(236,47): error TS1005: ',' expected.
    Error: node_modules/@types/node/http.d.ts(236,71): error TS1109: Expression expected.
    Error: node_modules/@types/node/http.d.ts(237,5): error TS1109: Expression expected.
    Error: node_modules/@types/node/http.d.ts(241,46): error TS1005: ',' expected.
    […]

I guess the type declaration files in question use TypeScript syntax that can't be parsed by TypeScript 4.5.5, which is used in the bootstrapped userscript.

I did a `git bisect` between `v5.0.0` and d1b8b4f (then the tip of the trunk), and #158 was identified as the first bad commit (see #164 for details).

But #158 made it through CI back in August 2024, when it was merged. So why does it fail now?

Well, when bisecting, #158 turned out to affect the output of `npm why @types/node` in the bootstrapped userscript in a quite interesting way:

```diff
@@ -1,24 +1,14 @@
-@types/node@12.20.55
+@types/node@22.14.0
 node_modules/@types/node
-  @types/node@"*" from @types/webpack@4.41.38
+  @types/node@"*" from @types/webpack@4.41.40
   node_modules/@types/webpack
-    @types/webpack@"^4" from @types/terser-webpack-plugin@2.2.3
-    node_modules/@types/terser-webpack-plugin
-      @types/terser-webpack-plugin@"^2.2.0" from userscripter@5.0.0
-      node_modules/userscripter
-        userscripter@"file:../../../../home/alling/dev/userscripter/userscripter-5.0.0.tgz" from the root project
     @types/webpack@"^4.39.9" from userscripter@5.0.0
     node_modules/userscripter
       userscripter@"file:../../../../home/alling/dev/userscripter/userscripter-5.0.0.tgz" from the root project
   @types/node@"*" from @types/webpack-sources@3.2.3
   node_modules/@types/webpack-sources
-    @types/webpack-sources@"*" from @types/webpack@4.41.38
+    @types/webpack-sources@"*" from @types/webpack@4.41.40
     node_modules/@types/webpack
-      @types/webpack@"^4" from @types/terser-webpack-plugin@2.2.3
-      node_modules/@types/terser-webpack-plugin
-        @types/terser-webpack-plugin@"^2.2.0" from userscripter@5.0.0
-        node_modules/userscripter
-          userscripter@"file:../../../../home/alling/dev/userscripter/userscripter-5.0.0.tgz" from the root project
       @types/webpack@"^4.39.9" from userscripter@5.0.0
       node_modules/userscripter
         userscripter@"file:../../../../home/alling/dev/userscripter/userscripter-5.0.0.tgz" from the root project
```

Apparently, #158 caused npm to install version 22.14.0 instead of 12.20.55 of `@types/node` – as of 2025-04-08, when [22.14.0 was the latest available version][v22.14.1].

Note in particular `@types/node@"*"` – to me, that `*` just _has_ to be part of the reason why npm picks the latest available version.

**In general, our CI setup just isn't deterministic, because `npm install` isn't.**

## Solution

I really don't know what a proper solution to this would be. I tried removing `@types/webpack`, but then all the dependent userscripts would fail like this in CI:

    Error: node_modules/userscripter/build-time/internal/webpack.d.ts(2,26): error TS7016: Could not find a declaration file for module 'webpack'. '/…/node_modules/webpack/lib/webpack.js' implicitly has an 'any' type.
      Try `npm install @types/webpack` if it exists or add a new declaration (.d.ts) file containing `declare module 'webpack';`

I need to do _something_ just to be able to make any changes at all. The best I've been able to come up with for now is making dependent userscripts get a deterministic version of `@types/node` that they can parse.

Major version 16 seems like the right choice because that's currently the only version of Node we support (see `ci.yaml`). I've decided to go with v16.18.31 because it's the newest version that seems to work. With v16.18.32, Example Userscript fails like this in CI:

    Error: node_modules/@types/node/ts4.8/buffer.d.ts(340,48): error TS2694: Namespace 'global.NodeJS' has no exported member 'ArrayBufferView'.

Resolves #164.

[v22.14.1]: https://www.npmjs.com/package/@types/node?activeTab=versions