### PR TITLE
ci!: Support Node 22; drop Node 16 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [16.20.2]
+        node-version: [22.14.0]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [16.20.2]
+        node-version: [22.14.0]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -81,7 +81,7 @@ jobs:
             ownerSlashName: SimonAlling/userscripter
             refInRepo: ${{ github.sha }} # The purpose here, unlike in the `bootstrap` job, _is_ to check how any changes to the library/package might affect the bootstrapped userscript.
             pathInRepo: bootstrap/
-        node-version: [16.20.2]
+        node-version: [22.14.0]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Node 16 [has been EOL since 2023-09-11][eol]. The current Active LTS [is Node 22][active].

In addition to the changes in this PR, I had to go to [the branch protection rule for `master`][rule] and update the required status checks under _Require status checks to pass before merging_.

[eol]: https://nodejs.org/en/blog/announcements/nodejs16-eol
[active]: https://nodejs.org/en/about/previous-releases
[rule]: https://github.com/SimonAlling/userscripter/settings/branch_protection_rules/17488390