### PR TITLE
chore: v6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "userscripter",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "userscripter",
-      "version": "5.1.0",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "16.18.31",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userscripter",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Create userscripts in a breeze!",
   "keywords": [
     "userscript",


### PR DESCRIPTION
This release drops support for Node 16 in favor of Node 22.

## Migration guide

You should migrate to Node 22 in your development environment to avoid any potential breakage in upcoming non-major releases.