### PR TITLE
chore: Upgrade @types/node to v22.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "16.18.31",
+        "@types/node": "22.14.1",
         "@types/sass": "^1.16.0",
         "@types/webpack": "^4.41.38",
         "css-loader": "^3.2.0",
@@ -1871,10 +1871,13 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "node_modules/@types/node": {
-      "version": "16.18.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
-      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw==",
-      "license": "MIT"
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/sass": {
       "version": "1.16.0",
@@ -13204,6 +13207,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -15508,9 +15517,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@types/node": {
-      "version": "16.18.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.31.tgz",
-      "integrity": "sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw=="
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/sass": {
       "version": "1.16.0",
@@ -24163,6 +24175,11 @@
           "dev": true
         }
       }
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "ts-preferences": "^2.0.0"
   },
   "dependencies": {
-    "@types/node": "16.18.31",
+    "@types/node": "22.14.1",
     "@types/sass": "^1.16.0",
     "@types/webpack": "^4.41.38",
     "css-loader": "^3.2.0",


### PR DESCRIPTION
In #169, we dropped support for Node 16 in favor of Node 22. I guess it makes sense to upgrade `@types/node` accordingly.