### PR TITLE
ci: Update dependent userscripts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,11 +71,11 @@ jobs:
         repository:
           - humanReadableName: Better SweClockers
             ownerSlashName: SimonAlling/better-sweclockers
-            refInRepo: e63484ef0091c8c92de1bc6e3c2ddb0749735a8b
+            refInRepo: 64ddf8a1541356261c4eebeeedfdb408b41b2d42
             pathInRepo: ""
           - humanReadableName: Example Userscript
             ownerSlashName: SimonAlling/example-userscript
-            refInRepo: d1d30ea54062a620179784159f9a922d30ecc696
+            refInRepo: b42b8717c421cf5dca5c6e4bc2ee8396125bd6bb
             pathInRepo: ""
           - humanReadableName: Bootstrapped Userscript
             ownerSlashName: SimonAlling/userscripter


### PR DESCRIPTION
The purpose of building dependent userscripts in CI is to identify breaking changes before merging them. This PR updates the dependent userscripts to versions with Userscripter 6.0.0 (see SimonAlling/better-sweclockers#275 and SimonAlling/example-userscript#33), so that breaking changes are identified relative to the current major release, which is the entire point.