### PR TITLE
build!: Upgrade to TypeScript 5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "rimraf": "5.0.7",
         "ts-jest": "29.2.3",
         "ts-preferences": "^2.0.0",
-        "typescript": "4.5.5"
+        "typescript": "5.0.4"
       },
       "peerDependencies": {
         "ts-preferences": "^2.0.0"
@@ -13157,15 +13157,16 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/typical": {
@@ -24134,9 +24135,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
     "typical": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "rimraf": "5.0.7",
     "ts-jest": "29.2.3",
     "ts-preferences": "^2.0.0",
-    "typescript": "4.5.5"
+    "typescript": "5.0.4"
   },
   "peerDependencies": {
     "ts-preferences": "^2.0.0"


### PR DESCRIPTION
While this probably doesn't break any existing userscripts, I consider this a BREAKING change because upgrading to a new TypeScript version means that future changes might accidentally introduce syntax not supported by earlier versions. Also, I'm looking into [Semantic Versioning for TypeScript Types](https://www.semver-ts.org), which lists two "recommended support policies for TypeScript compiler versions":

> * In _simple majors_, dropping support for a previously supported compiler version requires a breaking change.
>
> * In _rolling window_, a package may declare a range of supported versions which moves over time, similar to supporting evergreen browsers.

In the absence of a documented support policy, I think it makes sense to default to _simple majors_.