### PR TITLE
chore: v7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "userscripter",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "userscripter",
-      "version": "6.0.0",
+      "version": "7.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/node": "16.18.31",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "userscripter",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Create userscripts in a breeze!",
   "keywords": [
     "userscript",


### PR DESCRIPTION
This release drops support for TypeScript 4.5 in favor of TypeScript 5.0.

## Migration guide

You should migrate to TypeScript 5.0 to avoid any potential breakage in upcoming non-major releases.