### PR TITLE
chore: Use v7.0.0 in bootstrapped userscript

### DIFF
--- a/bootstrap/package-lock.json
+++ b/bootstrap/package-lock.json
@@ -12,7 +12,7 @@
         "ts-preferences": "^2.0.0",
         "typescript": "4.5.5",
         "userscript-metadata": "^1.0.0",
-        "userscripter": "6.0.0",
+        "userscripter": "7.0.0",
         "webpack": "^4.41.5",
         "webpack-cli": "^3.3.10"
       }
@@ -5018,9 +5018,9 @@
       }
     },
     "node_modules/userscripter": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-6.0.0.tgz",
-      "integrity": "sha512-y0KFhrMgxh3o9PNjGHWNK7u9J9tJJPmLJ/LVnFWgbD8Z4OvHzCbEwa/7PsaL+xdI5/ggQ+xLtAOx8kLHjV/otA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-7.0.0.tgz",
+      "integrity": "sha512-fQQJagkzGVjoPdQFa0ygVIegFMNY86ci8iRvbIKnyJh1GrgfxLwOWbPVH9DCsc1dvQ32aFQ89Z9yj1Hn8PXriA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "16.18.31",
@@ -9633,9 +9633,9 @@
       }
     },
     "userscripter": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-6.0.0.tgz",
-      "integrity": "sha512-y0KFhrMgxh3o9PNjGHWNK7u9J9tJJPmLJ/LVnFWgbD8Z4OvHzCbEwa/7PsaL+xdI5/ggQ+xLtAOx8kLHjV/otA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/userscripter/-/userscripter-7.0.0.tgz",
+      "integrity": "sha512-fQQJagkzGVjoPdQFa0ygVIegFMNY86ci8iRvbIKnyJh1GrgfxLwOWbPVH9DCsc1dvQ32aFQ89Z9yj1Hn8PXriA==",
       "requires": {
         "@types/node": "16.18.31",
         "@types/sass": "^1.16.0",

--- a/bootstrap/package-lock.json
+++ b/bootstrap/package-lock.json
@@ -10,7 +10,7 @@
         "app-root-path": "^3.0.0",
         "rimraf": "^6.0.1",
         "ts-preferences": "^2.0.0",
-        "typescript": "4.5.5",
+        "typescript": "5.0.4",
         "userscript-metadata": "^1.0.0",
         "userscripter": "7.0.0",
         "webpack": "^4.41.5",
@@ -4868,15 +4868,16 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/union-value": {
@@ -9508,9 +9509,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/bootstrap/package.json
+++ b/bootstrap/package.json
@@ -12,7 +12,7 @@
     "app-root-path": "^3.0.0",
     "rimraf": "^6.0.1",
     "ts-preferences": "^2.0.0",
-    "typescript": "4.5.5",
+    "typescript": "5.0.4",
     "userscript-metadata": "^1.0.0",
     "userscripter": "7.0.0",
     "webpack": "^4.41.5",

--- a/bootstrap/package.json
+++ b/bootstrap/package.json
@@ -14,7 +14,7 @@
     "ts-preferences": "^2.0.0",
     "typescript": "4.5.5",
     "userscript-metadata": "^1.0.0",
-    "userscripter": "6.0.0",
+    "userscripter": "7.0.0",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10"
   }


### PR DESCRIPTION
TypeScript is also upgraded to version 5.0 because that's the version we implicitly support in v7.0.0 (see #178 and #179).